### PR TITLE
Add guide for tool commands, closes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,139 @@
 # Simple CLI for manipulation VMs through libvirt-daemon
 
+## Tool Guide
+
+This tool is supposed to be used as light-weight and easy utility for virtual machines (VM) manipulations.
+
+### VM Creation
+
+Create a machine "asgard" with defaults mem, disk and cpu. Machine name must be unique across your host OS.
+
+```
+$ libverter create asgard
+asgard created
+```
+
+Create a machine "noatun" with 2 CPU, 3 Gb drive and 100 Mb of memory use
+
+```
+$ libverter create -c 2 -m 100 -d 3 noatun
+noatun created
+```
+
+Create a "hell" machine using predefined sizes use option `-s` (size):
+
+```
+$ libverter create -s tiny hell
+hell created
+```
+
+Create a QEMU machine "jotunheim" use option `-t` (type):
+
+```
+liverter create -t qemu jotunheim
+jotunheim created
+```
+
+Create a KVM machine with a random name:
+
+```
+$ libverter create -t kvm
+asdfadf created
+```
+
+### VM Status
+
+To get "asgard" machine status call:
+
+```
+$ libverter status asgard
+asgard is running
+```
+
+For a not running machine output will be:
+
+```
+asgard is stopped
+```
+
+If a VM does not exists you will receive following output and non-zero return code:
+
+```
+asgard not found
+```
+
+To get more information about a machine use option `-a`: 
+
+```
+$ libverter status -a asgard
+name: asgard
+state: running
+type: qemu
+cpu: 1
+memory: 512 Mb
+disk: 3 Gb
+uptime: 1h 12m 13s
+```
+
+### VM List (TBD)
+
+To get VMs' list in a host OS call:
+
+```
+$ libverter list
+asgard
+hell
+noatun
+```
+
+Also, it's possible to provide a verbose list:
+
+```
+$ libverter list -v
+name	type	state	cpu	memory	disk	uptime
+asgard	qemu	running	1	512	3	1h12m12s
+noatun	kvm	stopped	2	1024	5	
+hell	qemu	stopped	1	512	1	
+```
+
+*Note:* Some other options can be disscussed later if needed.
+
+### VM Deletion
+
+To delete "asgard" machine call:
+
+```
+liberter delete asgard
+asgard deleted
+```
+
+### VM Starting
+
+To start "asgard" machine call:
+
+```
+$ libverter start asgard
+asgard started
+```
+
+### VM Stopping
+
+To stop "asgard" machine call:
+
+```
+$ libverter stop asgard
+asgard stopped
+```
+
+### VM Restarting
+
+To restart "asgard" machine call:
+
+```
+$ libverter restart asgard
+asgard restarted
+```
+
 ## Development
 
 ### Dependencies


### PR DESCRIPTION
This guide describes possible libverter commands usage.

Some notes:
- Command 'create' was extended with option '-t' (type). Option '-f' (flavor)
  was replaced with '-s' (size).
- Command 'status' was extended with option '-a' (all) providing different
  output. Possibly some other options can be added like '-c' (cpu),
  '-s' (state), '-m' (memory), '-d' (disk), '-u' (uptime), '-t' (type) and so on.
- Suggested command 'list' as well as its advanced advanced (option '-a') usage.
  There can be another options too (like in 'status') but they are not present
  because this command is needed to be discussed.
- For all commands it was suggested to remove parameter '-h' (hostname).
  In every cases hostname is supposed to be a unique identificator for VM
  and must be provided. So there are no sense to use a separate option for it.
- Suggested to remove option '-a' (action). Syntax 'libverter command vmname'
  seems to be shorter and more readable.